### PR TITLE
[fix] VisualBERT returns attention tuple #1036

### DIFF
--- a/mmf/modules/hf_layers.py
+++ b/mmf/modules/hf_layers.py
@@ -280,11 +280,17 @@ class BertEncoderJit(BertEncoder):
         attention_mask: Optional[Tensor],
         encoder_hidden_states: Optional[Tensor] = None,
         encoder_attention_mask: Optional[Tensor] = None,
-        output_attentions: bool = False,
-        output_hidden_states: bool = False,
+        output_attentions: bool = None,
+        output_hidden_states: bool = None,
         return_dict: bool = False,
         head_mask: Optional[Tensor] = None,
     ) -> Tuple[Tensor]:
+        
+        if output_attentions is None:
+            output_attentions = self.output_attentions            
+        if output_hidden_states is None:
+            output_hidden_states = self.output_hidden_states
+            
         all_hidden_states = ()
         all_attentions = ()
         for i, layer_module in enumerate(self.layer):


### PR DESCRIPTION
**PROBLEM**: The default value of output_attentions in forward( ) call of BertEncoderJit (`in mmf/modules/hf_layers.py`) is set as False. So even if the user/developer specifies `output_attentions = True` in config; its value is taken as default False and thus VisualBERT returns an empty tuple for attentions.

**FIX**: Set `output_attentions as None` in BertEncoderJit's forward( ) definition, and update output_attentions to self.output_attentions if it is not passed as an argument (i.e it is None). Therefore, now output_attentions will take the value of self.output_attentions (which was initialized using config during instantiation of BertEncoderJit class)

The issue with `output_hidden_states`  was the same, and it was fixed in a similar way. 

Tested locally.